### PR TITLE
Fix external CSS 404 in FATE dice roller

### DIFF
--- a/fate-roller-v2.html
+++ b/fate-roller-v2.html
@@ -4,7 +4,6 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Rolador FATE V2</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css">
 <style>
   body {
     background: #2a2a2a;


### PR DESCRIPTION
## Summary
- remove the Font Awesome CDN link from `fate-roller-v2.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841e8b800d0832e936c74ce360e9bd5