### PR TITLE
Add noir5 dice roller

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,7 @@ The file `dice-roller-v2.html` provides an improved dark-theme interface for rol
 ## Dice Roller V4
 
 The file `dice-roller-v4.html` adds per-die color customization with a modern neon look. Click the plus button to add a die with the chosen color, then roll to see each die displayed in its own color.
+
+## Noir5
+
+`noir5.html` improves the noir interface with easier color picking, results grouped by die type and a floating **Clear** button.

--- a/noir5.css
+++ b/noir5.css
@@ -1,0 +1,32 @@
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:'Space Grotesk',sans-serif;background:#0d0d0d;color:#fff;min-height:100vh;display:flex;overflow:hidden;position:relative}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='40' height='40'%3E%3Crect width='2' height='2' fill='white'/%3E%3C/svg%3E");opacity:.04}
+.sidebar{position:fixed;top:0;left:0;width:clamp(70px,18vw,110px);height:100vh;padding-top:40px;display:flex;flex-direction:column;align-items:center;gap:20px;transition:transform .3s}
+.sidebar:hover{transform:translateX(5px)}
+.icon{position:relative;width:60px;height:60px;cursor:pointer}
+.icon svg{stroke:#777;fill:none;width:100%;height:100%;transition:.3s}
+.icon.active svg{stroke:var(--c)}
+.icon:focus svg,.icon:hover svg{stroke:#ff0066}
+.badge{position:absolute;top:-5px;right:-5px;background:#ff0066;color:#000;border-radius:50%;padding:2px 6px;font-size:.75rem}
+main{flex:1;margin-left:clamp(70px,18vw,110px);padding:40px;display:flex;flex-direction:column;gap:20px;backdrop-filter:blur(4px)}
+#results{display:flex;flex-wrap:wrap;gap:10px}
+.die{width:50px;height:50px;border-radius:8px;background:rgba(255,255,255,.1);display:flex;align-items:center;justify-content:center;font-size:1.4rem;font-weight:600;opacity:0;transform:translateY(-40px) rotate(-15deg);animation:show .6s forwards}
+@keyframes show{to{opacity:1;transform:translateY(0) rotate(0)}}
+#history{position:relative;overflow:hidden;height:1.5em}
+#history span{position:absolute;white-space:nowrap;animation:ticker 20s linear infinite}
+#history:hover span{animation-play-state:paused}
+@keyframes ticker{from{transform:translateX(100%)}to{transform:translateX(-100%)}}
+#history button{margin-right:8px}
+#roll{position:fixed;bottom:20px;right:20px;width:60px;height:60px;border-radius:50%;background:#33ccff;border:none;color:#000;font-size:1.1rem;cursor:pointer;box-shadow:0 0 10px #33ccff;transition:.3s;z-index:10}
+#roll:hover{box-shadow:0 0 20px #33ccff}
+@media(max-width:640px){#roll{width:72px;height:72px}}
+.picker{position:fixed;width:160px;height:160px;border-radius:50%;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center}
+.picker.show{display:flex}
+.picker button{position:absolute;width:40px;height:40px;border-radius:50%;border:none;transform:scale(.3);opacity:0;animation:pop .3s forwards;box-shadow:0 0 8px currentColor;cursor:pointer}
+@keyframes pop{to{transform:scale(1);opacity:1}}
+#results{display:flex;flex-direction:column;gap:16px}
+.dice-row{display:flex;align-items:center;gap:10px;flex-wrap:wrap}
+.dice-row .label{width:50px;font-weight:600;text-transform:uppercase}
+.dice-row .dice-container{display:flex;flex-wrap:wrap;gap:10px}
+#clear{position:fixed;bottom:20px;right:90px;width:60px;height:60px;border-radius:50%;background:#ff0066;border:none;color:#000;font-size:1.1rem;cursor:pointer;box-shadow:0 0 10px #ff0066;transition:.3s;z-index:10}
+#clear:hover{box-shadow:0 0 20px #ff0066}

--- a/noir5.html
+++ b/noir5.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Dice Roller v5 Noir</title>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;600&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="noir5.css">
+</head>
+<body>
+<noscript>Enable JavaScript to roll dice.</noscript>
+<div class="sidebar" id="sidebar">
+  <div class="icon" data-type="fate" role="button" tabindex="0" aria-label="Fate dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><path d="M10 50h80M50 10v80"/></svg>
+  </div>
+  <div class="icon" data-type="d4" role="button" tabindex="0" aria-label="d4 dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><path d="M50 10L10 90h80Z"/></svg>
+  </div>
+  <div class="icon" data-type="d6" role="button" tabindex="0" aria-label="d6 dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><rect x="20" y="20" width="60" height="60" rx="10"/></svg>
+  </div>
+  <div class="icon" data-type="d8" role="button" tabindex="0" aria-label="d8 dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><polygon points="50,10 90,50 50,90 10,50"/></svg>
+  </div>
+  <div class="icon" data-type="d10" role="button" tabindex="0" aria-label="d10 dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><polygon points="50,10 85,35 75,90 25,90 15,35"/></svg>
+  </div>
+  <div class="icon" data-type="d20" role="button" tabindex="0" aria-label="d20 dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><polygon points="50,10 80,20 90,50 80,80 50,90 20,80 10,50 20,20"/></svg>
+  </div>
+  <div class="icon" data-type="d100" role="button" tabindex="0" aria-label="d100 dice">
+    <span class="badge">0</span>
+    <svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>
+  </div>
+</div>
+<main>
+  <div id="results" aria-live="polite"></div>
+  <div id="history"><span></span></div>
+</main>
+<button id="roll">Roll!</button>
+<button id="clear">Clear</button>
+<div id="picker" class="picker"></div>
+<script src="noir5.js"></script>
+</body>
+</html>

--- a/noir5.js
+++ b/noir5.js
@@ -1,0 +1,44 @@
+const counts={fate:0,d4:0,d6:0,d8:0,d10:0,d20:0,d100:0};
+const colors={fate:'#ff0066',d4:'#ff0066',d6:'#ff0066',d8:'#ff0066',d10:'#ff0066',d20:'#ff0066',d100:'#ff0066'};
+const neon=['#ff0066','#33ccff','#aaff00','#ff6600','#cc33ff'];
+const sidebar=document.getElementById('sidebar');
+const picker=document.getElementById('picker');
+let pressTimer,target,longPress;
+function updateBadges(){document.querySelectorAll('.icon').forEach(i=>i.querySelector('.badge').textContent=counts[i.dataset.type])}
+function rollDie(t){switch(t){case 'fate':return ['\u2212','0','+'][Math.floor(Math.random()*3)];case 'd4':return Math.floor(Math.random()*4)+1;case 'd6':return Math.floor(Math.random()*6)+1;case 'd8':return Math.floor(Math.random()*8)+1;case 'd10':return Math.floor(Math.random()*10)+1;case 'd20':return Math.floor(Math.random()*20)+1;case 'd100':return Math.floor(Math.random()*100)+1}}
+function addDie(type){counts[type]++;updateBadges()}
+function removeDie(type){if(counts[type]>0){counts[type]--;updateBadges()}}
+function buildPicker(x,y,type){picker.innerHTML='';neon.forEach((c,i)=>{const b=document.createElement('button');b.style.background=c;b.style.transform=`rotate(${i*72}deg) translate(60px)`;b.style.setProperty('--i',i);b.onclick=()=>{colors[type]=c;document.querySelector(`.icon[data-type="${type}"]`).style.setProperty('--c',c);document.querySelector(`.icon[data-type="${type}"]`).classList.add('active');picker.classList.remove('show')};picker.appendChild(b)});picker.style.left=`${x}px`;picker.style.top=`${y}px`;picker.classList.add('show')}
+sidebar.addEventListener('contextmenu',e=>{e.preventDefault();const t=e.target.closest('.icon');if(t)removeDie(t.dataset.type)});
+sidebar.addEventListener('click',e=>{const t=e.target.closest('.icon');if(t&&!longPress)addDie(t.dataset.type)});
+sidebar.addEventListener('mousedown',e=>{const t=e.target.closest('.icon');if(!t)return;longPress=false;pressTimer=setTimeout(()=>{longPress=true;buildPicker(e.clientX,e.clientY,t.dataset.type)},400)});
+sidebar.addEventListener('mouseup',()=>clearTimeout(pressTimer));
+sidebar.addEventListener('touchstart',e=>{const t=e.target.closest('.icon');if(!t)return;target=t;longPress=false;pressTimer=setTimeout(()=>{longPress=true;buildPicker(e.touches[0].clientX,e.touches[0].clientY,t.dataset.type)},400)});
+sidebar.addEventListener('touchend',e=>{clearTimeout(pressTimer);if(target&&!longPress)addDie(target.dataset.type);target=null});
+document.addEventListener('keydown',e=>{if((e.key==='Enter'||e.key===' ')&&document.activeElement.classList.contains('icon')){e.preventDefault();document.activeElement.click()}});
+document.addEventListener('click',e=>{if(!picker.contains(e.target))picker.classList.remove('show')});
+function getRow(type){let row=document.getElementById('row-'+type);if(!row){row=document.createElement('div');row.className='dice-row';row.id='row-'+type;const label=document.createElement('span');label.className='label';label.textContent=type;const cont=document.createElement('div');cont.className='dice-container';row.appendChild(label);row.appendChild(cont);document.getElementById('results').appendChild(row);}else{row.querySelector('.dice-container').innerHTML='';}return row.querySelector('.dice-container');}
+function roll(){
+  const res=document.getElementById('results');
+  res.innerHTML='';
+  const hist=document.querySelector('#history span');
+  let log='';
+  Object.keys(counts).forEach(t=>{
+    if(counts[t]>0){
+      const cont=getRow(t);
+      for(let i=0;i<counts[t];i++){
+        const v=rollDie(t);
+        const d=document.createElement('div');
+        d.className='die';
+        d.style.color=colors[t];
+        d.textContent=v;
+        cont.appendChild(d);
+        log+=v+' ';
+      }
+    }
+  });
+  hist.textContent=log+hist.textContent;
+}
+document.getElementById('roll').addEventListener('click',roll);
+document.getElementById('clear').addEventListener('click',()=>{document.querySelector('#history span').textContent=''});
+updateBadges();


### PR DESCRIPTION
## Summary
- add noir5 dice roller example
- support grouped results and easier color pick with noir5.js
- style rows and floating clear button via noir5.css
- document noir5 in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68434df985c0832ead9c405a1095ad7e