### PR TITLE
Enable color picker UI for Noir6 dice

### DIFF
--- a/noir6.css
+++ b/noir6.css
@@ -7,6 +7,7 @@ body::before{content:"";position:fixed;inset:0;pointer-events:none;background-im
 .icon svg{stroke:#777;fill:none;width:100%;height:100%;transition:.3s}
 .icon.active svg{stroke:var(--c)}
 .icon:focus svg,.icon:hover svg{stroke:#ff0066}
+.icon .palette{position:absolute;bottom:4px;right:4px;width:14px;height:14px;border-radius:50%;border:1px solid #fff;background:var(--c,#ff0066);cursor:pointer}
 .badge{position:absolute;top:-5px;right:-5px;background:#ff0066;color:#000;border-radius:50%;padding:2px 6px;font-size:.75rem}
 main{flex:1;margin-left:clamp(70px,18vw,110px);padding:40px;display:flex;flex-direction:column;gap:20px;backdrop-filter:blur(4px)}
 #results{display:flex;flex-wrap:wrap;gap:10px}

--- a/noir6.html
+++ b/noir6.html
@@ -13,30 +13,37 @@
   <div class="icon" data-type="fate" role="button" tabindex="0" aria-label="Fate dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><path d="M10 50h80M50 10v80"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
   <div class="icon" data-type="d4" role="button" tabindex="0" aria-label="d4 dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><path d="M50 10L10 90h80Z"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
   <div class="icon" data-type="d6" role="button" tabindex="0" aria-label="d6 dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><rect x="20" y="20" width="60" height="60" rx="10"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
   <div class="icon" data-type="d8" role="button" tabindex="0" aria-label="d8 dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><polygon points="50,10 90,50 50,90 10,50"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
   <div class="icon" data-type="d10" role="button" tabindex="0" aria-label="d10 dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><polygon points="50,10 85,35 75,90 25,90 15,35"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
   <div class="icon" data-type="d20" role="button" tabindex="0" aria-label="d20 dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><polygon points="50,10 80,20 90,50 80,80 50,90 20,80 10,50 20,20"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
   <div class="icon" data-type="d100" role="button" tabindex="0" aria-label="d100 dice">
     <span class="badge">0</span>
     <svg viewBox="0 0 100 100"><circle cx="50" cy="50" r="40"/></svg>
+    <button class="palette" aria-label="Escolher cor"></button>
   </div>
 </div>
 <main>

--- a/noir6.js
+++ b/noir6.js
@@ -3,6 +3,7 @@ const colors={fate:'#ff0066',d4:'#ff0066',d6:'#ff0066',d8:'#ff0066',d10:'#ff0066
 const sidebar=document.getElementById('sidebar');
 let pressTimer,target,longPress;
 function updateBadges(){document.querySelectorAll('.icon').forEach(i=>i.querySelector('.badge').textContent=counts[i.dataset.type])}
+function applyColors(){document.querySelectorAll('.icon').forEach(i=>{const t=i.dataset.type;i.style.setProperty('--c',colors[t]);const p=i.querySelector('.palette');if(p)p.style.background=colors[t]})}
 function rollDie(t){switch(t){case 'fate':return ['\u2212','0','+'][Math.floor(Math.random()*3)];case 'd4':return Math.floor(Math.random()*4)+1;case 'd6':return Math.floor(Math.random()*6)+1;case 'd8':return Math.floor(Math.random()*8)+1;case 'd10':return Math.floor(Math.random()*10)+1;case 'd20':return Math.floor(Math.random()*20)+1;case 'd100':return Math.floor(Math.random()*100)+1}}
 function addDie(type){counts[type]++;updateBadges()}
 function removeDie(type){if(counts[type]>0){counts[type]--;updateBadges()}}
@@ -18,15 +19,25 @@ function openColorPicker(type){
     const icon=document.querySelector(`.icon[data-type="${type}"]`);
     icon.style.setProperty('--c',input.value);
     icon.classList.add('active');
+    const pal=icon.querySelector('.palette');
+    if(pal) pal.style.background=input.value;
   });
   input.addEventListener('change',()=>input.remove());
   input.click();
 }
 sidebar.addEventListener('contextmenu',e=>{e.preventDefault();const t=e.target.closest('.icon');if(t)removeDie(t.dataset.type)});
-sidebar.addEventListener('click',e=>{const t=e.target.closest('.icon');if(t&&!longPress)addDie(t.dataset.type)});
-sidebar.addEventListener('mousedown',e=>{const t=e.target.closest('.icon');if(!t)return;longPress=false;pressTimer=setTimeout(()=>{longPress=true;openColorPicker(t.dataset.type)},400)});
+sidebar.addEventListener('click',e=>{
+  if(e.target.classList.contains('palette')){
+    openColorPicker(e.target.parentElement.dataset.type);
+    e.stopPropagation();
+    return;
+  }
+  const t=e.target.closest('.icon');
+  if(t&&!longPress)addDie(t.dataset.type)
+});
+sidebar.addEventListener('mousedown',e=>{const t=e.target.closest('.icon');if(!t||e.target.classList.contains('palette'))return;longPress=false;pressTimer=setTimeout(()=>{longPress=true;openColorPicker(t.dataset.type)},400)});
 sidebar.addEventListener('mouseup',()=>clearTimeout(pressTimer));
-sidebar.addEventListener('touchstart',e=>{const t=e.target.closest('.icon');if(!t)return;target=t;longPress=false;pressTimer=setTimeout(()=>{longPress=true;openColorPicker(t.dataset.type)},400)});
+sidebar.addEventListener('touchstart',e=>{const t=e.target.closest('.icon');if(!t||e.target.classList.contains('palette'))return;target=t;longPress=false;pressTimer=setTimeout(()=>{longPress=true;openColorPicker(t.dataset.type)},400)});
 sidebar.addEventListener('touchend',e=>{clearTimeout(pressTimer);if(target&&!longPress)addDie(target.dataset.type);target=null});
 document.addEventListener('keydown',e=>{if((e.key==='Enter'||e.key===' ')&&document.activeElement.classList.contains('icon')){e.preventDefault();document.activeElement.click()}});
 function getRow(type){let row=document.getElementById('row-'+type);if(!row){row=document.createElement('div');row.className='dice-row';row.id='row-'+type;const label=document.createElement('span');label.className='label';label.textContent=type;const cont=document.createElement('div');cont.className='dice-container';row.appendChild(label);row.appendChild(cont);document.getElementById('results').appendChild(row);}else{row.querySelector('.dice-container').innerHTML='';}return row.querySelector('.dice-container');}
@@ -54,3 +65,4 @@ function roll(){
 document.getElementById('roll').addEventListener('click',roll);
 document.getElementById('clear').addEventListener('click',()=>{document.querySelector('#history span').textContent=''});
 updateBadges();
+applyColors();


### PR DESCRIPTION
## Summary
- add color palette button inside each icon in `noir6.html`
- style palette buttons in `noir6.css`
- update `noir6.js` with helpers and events to open the color picker when palette button is clicked
- apply chosen colors to icons and palette swatches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68435218ac64832ebdaccdf341620dce