### PR TITLE
Fix Clear button and color picker in noir5

### DIFF
--- a/noir5.css
+++ b/noir5.css
@@ -19,7 +19,7 @@ main{flex:1;margin-left:clamp(70px,18vw,110px);padding:40px;display:flex;flex-di
 #history button{margin-right:8px}
 #roll{position:fixed;bottom:20px;right:20px;width:60px;height:60px;border-radius:50%;background:#33ccff;border:none;color:#000;font-size:1.1rem;cursor:pointer;box-shadow:0 0 10px #33ccff;transition:.3s;z-index:10}
 #roll:hover{box-shadow:0 0 20px #33ccff}
-@media(max-width:640px){#roll{width:72px;height:72px}}
+@media(max-width:640px){#roll,#clear{width:72px;height:72px}}
 .picker{position:fixed;width:160px;height:160px;border-radius:50%;background:rgba(0,0,0,.6);display:none;align-items:center;justify-content:center}
 .picker.show{display:flex}
 .picker button{position:absolute;width:40px;height:40px;border-radius:50%;border:none;transform:scale(.3);opacity:0;animation:pop .3s forwards;box-shadow:0 0 8px currentColor;cursor:pointer}

--- a/noir5.js
+++ b/noir5.js
@@ -1,6 +1,10 @@
 const counts={fate:0,d4:0,d6:0,d8:0,d10:0,d20:0,d100:0};
 const colors={fate:'#ff0066',d4:'#ff0066',d6:'#ff0066',d8:'#ff0066',d10:'#ff0066',d20:'#ff0066',d100:'#ff0066'};
-const neon=['#ff0066','#33ccff','#aaff00','#ff6600','#cc33ff'];
+// color palette used for the radial picker
+const neon=[
+  '#ff0066','#33ccff','#aaff00','#ff6600',
+  '#cc33ff','#00ff99','#ffcc00','#0099ff'
+];
 const sidebar=document.getElementById('sidebar');
 const picker=document.getElementById('picker');
 let pressTimer,target,longPress;
@@ -8,7 +12,29 @@ function updateBadges(){document.querySelectorAll('.icon').forEach(i=>i.querySel
 function rollDie(t){switch(t){case 'fate':return ['\u2212','0','+'][Math.floor(Math.random()*3)];case 'd4':return Math.floor(Math.random()*4)+1;case 'd6':return Math.floor(Math.random()*6)+1;case 'd8':return Math.floor(Math.random()*8)+1;case 'd10':return Math.floor(Math.random()*10)+1;case 'd20':return Math.floor(Math.random()*20)+1;case 'd100':return Math.floor(Math.random()*100)+1}}
 function addDie(type){counts[type]++;updateBadges()}
 function removeDie(type){if(counts[type]>0){counts[type]--;updateBadges()}}
-function buildPicker(x,y,type){picker.innerHTML='';neon.forEach((c,i)=>{const b=document.createElement('button');b.style.background=c;b.style.transform=`rotate(${i*72}deg) translate(60px)`;b.style.setProperty('--i',i);b.onclick=()=>{colors[type]=c;document.querySelector(`.icon[data-type="${type}"]`).style.setProperty('--c',c);document.querySelector(`.icon[data-type="${type}"]`).classList.add('active');picker.classList.remove('show')};picker.appendChild(b)});picker.style.left=`${x}px`;picker.style.top=`${y}px`;picker.classList.add('show')}
+function buildPicker(x,y,type){
+  picker.innerHTML='';
+  const angle=360/neon.length;
+  neon.forEach((c,i)=>{
+    const b=document.createElement('button');
+    b.style.background=c;
+    b.style.transform=`rotate(${i*angle}deg) translate(60px)`;
+    b.onclick=()=>{
+      colors[type]=c;
+      const icon=document.querySelector(`.icon[data-type="${type}"]`);
+      icon.style.setProperty('--c',c);
+      icon.classList.add('active');
+      picker.classList.remove('show');
+    };
+    picker.appendChild(b);
+  });
+  const size=80; // picker radius
+  x=Math.min(Math.max(x,size),window.innerWidth-size);
+  y=Math.min(Math.max(y,size),window.innerHeight-size);
+  picker.style.left=`${x}px`;
+  picker.style.top=`${y}px`;
+  picker.classList.add('show');
+}
 sidebar.addEventListener('contextmenu',e=>{e.preventDefault();const t=e.target.closest('.icon');if(t)removeDie(t.dataset.type)});
 sidebar.addEventListener('click',e=>{const t=e.target.closest('.icon');if(t&&!longPress)addDie(t.dataset.type)});
 sidebar.addEventListener('mousedown',e=>{const t=e.target.closest('.icon');if(!t)return;longPress=false;pressTimer=setTimeout(()=>{longPress=true;buildPicker(e.clientX,e.clientY,t.dataset.type)},400)});
@@ -40,5 +66,10 @@ function roll(){
   hist.textContent=log+hist.textContent;
 }
 document.getElementById('roll').addEventListener('click',roll);
-document.getElementById('clear').addEventListener('click',()=>{document.querySelector('#history span').textContent=''});
+document.getElementById('clear').addEventListener('click',()=>{
+  Object.keys(counts).forEach(k=>counts[k]=0);
+  updateBadges();
+  document.getElementById('results').innerHTML='';
+  document.querySelector('#history span').textContent='';
+});
 updateBadges();


### PR DESCRIPTION
## Summary
- adjust mobile sizes for roll and clear buttons
- expand noir5 color palette to 8 fixed colors
- ensure color picker stays within viewport and adapt rotation for 8 colors
- reset counts and results when clicking Clear

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68446be4689c832eb1c3849a7d699ad0