### PR TITLE
Add help popup and improve clear in noir7

### DIFF
--- a/noir7.css
+++ b/noir7.css
@@ -27,5 +27,9 @@ main{flex:1;margin-left:clamp(70px,18vw,110px);padding:40px;display:flex;flex-di
 .dice-row .dice-container{display:flex;flex-wrap:wrap;gap:10px}
 #clear{position:fixed;bottom:20px;right:90px;width:60px;height:60px;border-radius:50%;background:#ff0066;border:none;color:#000;font-size:1.1rem;cursor:pointer;box-shadow:0 0 10px #ff0066;transition:.3s;z-index:10}
 #clear:hover{box-shadow:0 0 20px #ff0066}
+.help-popup{position:fixed;bottom:80px;left:20px;background:rgba(0,0,0,.9);padding:10px;border-radius:8px;max-width:200px;font-size:.9rem;line-height:1.3;display:none;z-index:20}
+.help-popup.show{display:block}
+#help{position:fixed;bottom:20px;left:20px;width:40px;height:40px;border-radius:50%;background:#555;border:none;color:#fff;font-size:1.1rem;cursor:pointer;opacity:.6;z-index:10}
+#help:hover{opacity:1}
 .palette-picker{position:absolute;background:rgba(0,0,0,.8);padding:6px;border-radius:8px;display:flex;flex-wrap:wrap;gap:6px;z-index:20}
 .palette-picker button{width:26px;height:26px;border-radius:50%;border:none;box-shadow:0 0 4px currentColor;cursor:pointer}

--- a/noir7.html
+++ b/noir7.html
@@ -45,6 +45,11 @@
 </main>
 <button id="roll">Roll!</button>
 <button id="clear">Clear</button>
+<button id="help" aria-label="Ajuda">?</button>
+<div id="help-popup" class="help-popup">
+  Clique nos dados para adicioná-los. Use o botão direito para remover. Depois
+  pressione <strong>Roll!</strong> para rolar e ver o histórico.
+</div>
 <script src="noir7.js"></script>
 </body>
 </html>

--- a/noir7.js
+++ b/noir7.js
@@ -117,6 +117,13 @@ document.getElementById('roll').addEventListener('click',()=>{
 
 document.getElementById('clear').addEventListener('click',()=>{
   document.querySelector('#history span').textContent='';
+  document.getElementById('results').innerHTML='';
+  Object.keys(counts).forEach(t=>{counts[t]=[];});
+  updateBadges();
+});
+
+document.getElementById('help').addEventListener('click',()=>{
+  document.getElementById('help-popup').classList.toggle('show');
 });
 
 updateBadges();


### PR DESCRIPTION
## Summary
- add help button and popup to noir7
- enhance clear button to reset all dice and history

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e3757acc832e91dac703b8aaee14