### PR TITLE
Add Tableau certification wiki

### DIFF
--- a/tableau-wiki.html
+++ b/tableau-wiki.html
@@ -1,0 +1,132 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Manual Tableau Wiki</title>
+<link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;700&display=swap" rel="stylesheet">
+<style>
+ body { font-family:'Space Grotesk',sans-serif; margin:0; background:#111; color:#eee; line-height:1.6; }
+ header, main { max-width:960px; margin:auto; padding:1rem; }
+ nav ul { list-style:none; padding-left:0; }
+ nav li { margin:.25rem 0; }
+ a { color:#79f; text-decoration:none; }
+ a:hover { text-decoration:underline; }
+ h1,h2,h3 { color:#f5a; margin-top:1.4rem; }
+ table { width:100%; border-collapse:collapse; margin:1rem 0; }
+ th,td { border:1px solid #444; padding:.5rem; text-align:left; }
+</style>
+</head>
+<body>
+<header>
+ <h1>Manual Prático: Carreira com Certificação Tableau</h1>
+ <p>Do zero à vaga de Consultant (2025)</p>
+</header>
+<nav>
+ <ul>
+  <li><a href="#intro">Capítulo 1 – Introdução</a></li>
+  <li><a href="#vagas">Capítulo 2 – Vagas por Certificação</a></li>
+  <li><a href="#trilha">Capítulo 3 – Trilha de Certificações</a></li>
+  <li><a href="#estudo">Capítulo 4 – Trilha de Estudo</a></li>
+  <li><a href="#emprego">Capítulo 5 – Conseguindo Emprego</a></li>
+  <li><a href="#recursos">Capítulo 6 – Glossário e Recursos</a></li>
+ </ul>
+</nav>
+<main>
+<section id="intro">
+<h2>O que é Tableau?</h2>
+<p>Tableau é uma das principais ferramentas de Business Intelligence (BI). Permite criar dashboards e relatórios de forma visual e rápida para ajudar empresas a tomar decisões baseadas em dados.</p>
+<p><strong>Público-alvo:</strong></p>
+<ul>
+ <li>Interessados em análise de dados, BI ou consultoria.</li>
+ <li>Profissionais de qualquer formação querendo migrar para dados.</li>
+</ul>
+<h3>Por que vale a pena?</h3>
+<ul>
+ <li><strong>Mercado aquecido:</strong> diversas áreas buscam profissionais com Tableau.</li>
+ <li><strong>Salário bom:</strong> Analistas de BI podem ganhar de R$6k a mais de R$15k.</li>
+ <li><strong>Baixa barreira de entrada:</strong> não exige programação.</li>
+ <li><strong>Trampo no Brasil e exterior:</strong> projetos remotos em empresas internacionais.</li>
+</ul>
+</section>
+<section id="vagas">
+<h2>Quais Vagas Você Pode Alcançar</h2>
+<h3>Salesforce Certified Tableau Desktop Foundations</h3>
+<p>Primeiro degrau para quem está começando. Vagas de estágio ou júnior.</p>
+<h3>Salesforce Certified Tableau Data Analyst</h3>
+<p>Mostra domínio real de análise e dashboards elaborados. Alvo de vagas pleno.</p>
+<h3>Salesforce Certified Tableau Consultant</h3>
+<p>Perfil consultivo para liderar projetos de BI e atuar com clientes.</p>
+<table>
+<thead><tr><th>Certificação</th><th>Vagas possíveis</th><th>Salário Médio (BR)</th></tr></thead>
+<tbody>
+<tr><td>Desktop Foundations</td><td>Estágio/Júnior BI</td><td>R$ 2k ~ R$ 4,5k</td></tr>
+<tr><td>Data Analyst</td><td>Analista Pleno BI</td><td>R$ 6k ~ R$ 11k</td></tr>
+<tr><td>Consultant</td><td>Consultor Tableau</td><td>R$ 9k ~ R$ 18k+</td></tr>
+</tbody>
+</table>
+</section>
+<section id="trilha">
+<h2>Trilha de Certificações</h2>
+<h3>1. Tableau Desktop Foundations</h3>
+<p>Valida uso básico da interface, conexões e dashboards simples.</p>
+<h3>2. Tableau Data Analyst</h3>
+<p>Foca em conectar diferentes fontes, limpar dados e criar dashboards interativos.</p>
+<h3>3. Tableau Consultant</h3>
+<p>Envolve melhores práticas, governança e liderança de projetos.</p>
+<table>
+<thead><tr><th>Certificação</th><th>Nível</th><th>O que cobre</th><th>Indicado para</th></tr></thead>
+<tbody>
+<tr><td>Foundations</td><td>Iniciante</td><td>Interface, conexões, visual básico</td><td>Entrando em BI</td></tr>
+<tr><td>Data Analyst</td><td>Intermediário</td><td>Análise e dashboards interativos</td><td>Analista pleno</td></tr>
+<tr><td>Consultant</td><td>Avançado</td><td>Projetos, consultoria, governança</td><td>Liderança em BI</td></tr>
+</tbody>
+</table>
+</section>
+<section id="estudo">
+<h2>Trilha de Estudo</h2>
+<h3>Desktop Foundations</h3>
+<ol>
+ <li>Estude módulos "Get Started with Tableau" e "Build Visualizations and Dashboards" no Trailhead.</li>
+ <li>Pratique com Tableau Public.</li>
+ <li>Leia o Exam Guide Foundations.</li>
+ <li>Faça simulados.</li>
+</ol>
+<h3>Data Analyst</h3>
+<ol>
+ <li>Domine módulos de análise e integração de dados.</li>
+ <li>Crie projetos próprios e publique dashboards.</li>
+ <li>Leia o Exam Guide Data Analyst.</li>
+ <li>Faça simulados.</li>
+</ol>
+<h3>Consultant</h3>
+<ol>
+ <li>Estude melhores práticas consultivas e governança.</li>
+ <li>Pratique casos reais e simulações.</li>
+ <li>Leia o Exam Guide Consultant.</li>
+</ol>
+</section>
+<section id="emprego">
+<h2>Como Provar Valor e Conseguir o Primeiro Emprego</h2>
+<ul>
+ <li>Mantenha LinkedIn atualizado com as certificações.</li>
+ <li>Monte portfólio no Tableau Public.</li>
+ <li>Mostre dashboards reais em entrevistas.</li>
+ <li>Compartilhe estudos e dúvidas nas redes para networking.</li>
+</ul>
+</section>
+<section id="recursos">
+<h2>Glossário e Recursos Úteis</h2>
+<p><strong>Glossário rápido:</strong> Dashboard, Viz, Data Source, Worksheet, Filter, KPI, Publish, etc.</p>
+<p><strong>Recursos oficiais:</strong></p>
+<ul>
+ <li><a href="https://trailhead.salesforce.com/academy">Trailhead Academy</a></li>
+ <li><a href="https://public.tableau.com/">Tableau Public</a></li>
+ <li><a href="https://community.tableau.com/">Fórum Tableau</a></li>
+ <li><a href="https://www.linkedin.com/groups/8606833/">Comunidade Tableau Brasil</a></li>
+</ul>
+<p><em>Dica final:</em> Estude em grupo e compartilhe seus dashboards para crescer mais rápido.</p>
+</section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `tableau-wiki.html` with a simple navigation menu and sections on Tableau certifications

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_688d09a59128832e8259b3ec66658dae