### PR TITLE
Add modern HTML and CSS CV page

### DIFF
--- a/cv-modern.css
+++ b/cv-modern.css
@@ -1,0 +1,72 @@
+:root {
+  --primary-color: #2d3436;
+  --accent-color: #0984e3;
+  --background-color: #f5f5f5;
+  --card-background: #ffffff;
+  --font-family: 'Inter', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: var(--font-family);
+  background-color: var(--background-color);
+  color: var(--primary-color);
+  line-height: 1.6;
+}
+
+.container {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+header {
+  text-align: center;
+  margin-bottom: 2rem;
+}
+
+h1 {
+  margin: 0;
+  font-size: 2.2rem;
+  color: var(--accent-color);
+}
+
+h2 {
+  border-bottom: 2px solid var(--accent-color);
+  padding-bottom: 0.25rem;
+  margin-top: 2rem;
+}
+
+section {
+  background: var(--card-background);
+  padding: 1.5rem;
+  border-radius: 8px;
+  margin-bottom: 1.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.meta {
+  font-style: italic;
+  color: #636e72;
+  margin-top: -0.5rem;
+  margin-bottom: 0.5rem;
+}
+
+ul {
+  padding-left: 1.25rem;
+}
+
+.certifications .two-columns {
+  columns: 2;
+  column-gap: 2rem;
+}
+
+@media (max-width: 600px) {
+  .certifications .two-columns {
+    columns: 1;
+  }
+}

--- a/cv-modern.html
+++ b/cv-modern.html
@@ -1,0 +1,96 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Currículo Profissional</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="cv-modern.css">
+</head>
+<body>
+  <div class="container">
+    <header>
+      <h1>Currículo Profissional</h1>
+    </header>
+    <main>
+      <section class="experience">
+        <h2>Experiência Profissional</h2>
+        <article>
+          <h3>Product Owner - Plataforma Educacional</h3>
+          <ul>
+            <li>Criação de um LMS do zero com mais de 10 mil alunos e sistema de gamificação.</li>
+            <li>Conversão de conteúdo gratuito para cursos pagos, gerando crescimento expressivo da receita.</li>
+            <li>Implementação de modelo de assinatura, consolidando um negócio sustentável e lucrativo.</li>
+          </ul>
+        </article>
+        <article>
+          <h3>Product Owner - Editora Lorca</h3>
+          <p class="meta">Fevereiro de 2015 – Junho de 2017 | São Paulo, SP</p>
+          <ul>
+            <li>Criação de uma interface global de vendas, que aumentou as vendas online em 120%.</li>
+            <li>Implementação de modelo de vendas digitais, gerando um aumento de 12% no faturamento.</li>
+            <li>Gerenciamento de equipes internacionais, com atuação em espanhol e inglês.</li>
+          </ul>
+        </article>
+      </section>
+      <section class="education">
+        <h2>Formação Acadêmica</h2>
+        <ul>
+          <li><strong>Pós-Graduação em Liderança e Gestão de Pessoas</strong>, Descomplica (Dezembro de 2023)</li>
+          <li><strong>Pós-Graduação em Gestão de Produtos</strong>, Descomplica (Dezembro de 2022)</li>
+          <li><strong>MBA em Gestão Estratégica de Projetos e Metodologias Ágeis</strong>, Descomplica (Julho de 2022)</li>
+          <li><strong>Graduação em Publicidade e Propaganda</strong>, Belas Artes (Dezembro de 2009)</li>
+          <li><strong>Ensino Médio Técnico em Tecnologia da Informação</strong>, ETEC Camargo Aranha (Dezembro de 2004)</li>
+        </ul>
+      </section>
+      <section class="skills">
+        <h2>Competências Técnicas</h2>
+        <ul>
+          <li><strong>Metodologias Ágeis:</strong> SCRUM, Kanban, liderança de squads e otimização de entregas.</li>
+          <li><strong>Gestão de Produtos:</strong> Definição de roadmaps, priorização de backlog e ciclo de vida completo do produto.</li>
+          <li><strong>Ferramentas:</strong> Jira, SQL, Figma, Adobe XD – para prototipação e análise de dados.</li>
+          <li><strong>Análise de Dados:</strong> Data Analytics, Business Intelligence, e uso de métricas (NPS, LTV, churn) para decisões estratégicas.</li>
+          <li><strong>Liderança e Comunicação:</strong> Gestão de equipes cross-funcionais e alinhamento com stakeholders.</li>
+        </ul>
+      </section>
+      <section class="certifications">
+        <h2>Certificações e Cursos</h2>
+        <h3>Formações</h3>
+        <ul>
+          <li>Certified Scrum Product Owner (CSPO) – K21</li>
+          <li>Inteligência Artificial em Negócios Digitais</li>
+          <li>Product Discovery</li>
+          <li>Digital Product Leadership</li>
+        </ul>
+        <h3>Cursos</h3>
+        <ul class="two-columns">
+          <li>Introdução a Product Discovery</li>
+          <li>Plano estratégico para investimento em IA</li>
+          <li>Introdução ao Discovery Contínuo</li>
+          <li>Ideação e Teste de Soluções</li>
+          <li>Liderança e Negociação</li>
+          <li>Implementação ágil de IA Generativa</li>
+          <li>Pesquisa para PMs</li>
+          <li>Fundamentos da IA Generativa</li>
+          <li>Métricas e tomada de decisão com dados</li>
+          <li>Aplique os resultados do Discovery</li>
+          <li>Métricas para Produtos Digitais</li>
+          <li>Planejamento de Product Discovery</li>
+          <li>Fundamentos de Product Management</li>
+          <li>Definição e Validação do problema</li>
+          <li>Product Delivery: Construa a solução</li>
+        </ul>
+      </section>
+      <section class="languages">
+        <h2>Idiomas</h2>
+        <ul>
+          <li><strong>Inglês:</strong> Avançado</li>
+          <li><strong>Espanhol:</strong> Intermediário</li>
+        </ul>
+      </section>
+    </main>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create modern curriculum vitae page using semantic HTML and responsive CSS
- include sections for experience, education, skills, certifications, and languages

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b85d3410a4832e88588262d1808981